### PR TITLE
Added the Message Window implementation

### DIFF
--- a/PacMan.vcxproj
+++ b/PacMan.vcxproj
@@ -19,6 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="src\Windows\MessageWindow.cpp" />
     <ClCompile Include="src\MenuLists\MapMenuList.cpp" />
     <ClCompile Include="src\MapFile.cpp" />
     <ClCompile Include="src\MenuLists\MainMenuList.cpp" />
@@ -38,6 +39,7 @@
     <ClCompile Include="src\Windows\MapSelectorWindow.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="src\Windows\MessageWindow.h" />
     <ClInclude Include="src\Engine\UniquePtrUtils.h" />
     <ClInclude Include="src\MenuLists\MapMenuList.h" />
     <ClInclude Include="src\MapFile.h" />

--- a/PacMan.vcxproj.filters
+++ b/PacMan.vcxproj.filters
@@ -84,6 +84,9 @@
     <ClCompile Include="src\Windows\MapSelectorWindow.cpp">
       <Filter>Source Files\Windows</Filter>
     </ClCompile>
+    <ClCompile Include="src\Windows\MessageWindow.cpp">
+      <Filter>Source Files\Windows</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\PacMan.h">
@@ -145,6 +148,9 @@
     </ClInclude>
     <ClInclude Include="src\Engine\UniquePtrUtils.h">
       <Filter>Header Files\Engine</Filter>
+    </ClInclude>
+    <ClInclude Include="src\Windows\MessageWindow.h">
+      <Filter>Header Files\Windows</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/src/Windows/MessageWindow.cpp
+++ b/src/Windows/MessageWindow.cpp
@@ -20,24 +20,38 @@ void MessageWindow::render()
 	gPacMan.sendDataf(L'\u255A', bottomLeftPosRow, topLeftPosColumn);
 	gPacMan.sendDataf(L'\u255D', bottomLeftPosRow, topRightPosColumn);
 	// the horizontal bars
+	renderHorizontalCont(topLeftPosRow, topLeftPosColumn, bottomLeftPosRow);
+	// the vertical bars
+	renderVertCont(topLeftPosRow, topLeftPosColumn, topRightPosColumn);
+	// all text rendering
+	renderText(topLeftPosRow, topLeftPosColumn, topRightPosColumn, bottomLeftPosRow);
+}
+
+void MessageWindow::renderHorizontalCont(unsigned int topLeftPosRow, unsigned int topLeftPosColumn, unsigned int bottomLeftPosRow)
+{
 	for (unsigned int i{ 1 }; i < m_width; i++)
 	{
 		gPacMan.sendDataf(L'\u2550', topLeftPosRow, topLeftPosColumn + i);
 		gPacMan.sendDataf(L'\u2550', bottomLeftPosRow, topLeftPosColumn + i);
-		
+
 		// make the insides of the message window empty
 		for (unsigned int j{ 1 }; j < m_height; j++)
 			gPacMan.sendDataf(L' ', topLeftPosRow + j, topLeftPosColumn + i);
 	}
-	// the vertical bars
+}
+
+void MessageWindow::renderVertCont(unsigned int topLeftPosRow, unsigned int topLeftPosColumn, unsigned int topRightPosColumn)
+{
 	for (unsigned int i{ 1 }; i < m_height; i++)
 	{
 		gPacMan.sendDataf(L'\u2551', topLeftPosRow + i, topLeftPosColumn);
 		gPacMan.sendDataf(L'\u2551', topLeftPosRow + i, topRightPosColumn);
 	}
+}
 
-	// all text rendering happens below, only single-line text is supported for now
-
+// only single - line text is supported for now
+void MessageWindow::renderText(unsigned int topLeftPosRow, unsigned int topLeftPosColumn, unsigned int topRightPosColumn, unsigned int bottomLeftPosRow)
+{
 	// a lambda for wrapping up offset calculations
 	auto calcOffset{ [](unsigned int row1, unsigned int row2, unsigned int txtSize) {
 		return (row1 + row2) / 2 - txtSize / 2;
@@ -56,7 +70,7 @@ void MessageWindow::render()
 	gPacMan.sendDataf(m_msg.data(), textSize, textRow, textColumn);
 
 	// the "OK" text
-	gPacMan.sendDataf(L"> OK <", 6, bottomLeftPosRow - textBorderDist, calcOffset(topLeftPosColumn, topRightPosColumn, 6) );
+	gPacMan.sendDataf(L"> OK <", 6, bottomLeftPosRow - textBorderDist, calcOffset(topLeftPosColumn, topRightPosColumn, 6));
 }
 
 void MessageWindow::runLogic()

--- a/src/Windows/MessageWindow.cpp
+++ b/src/Windows/MessageWindow.cpp
@@ -52,15 +52,18 @@ void MessageWindow::renderVertCont(unsigned int topLeftPosRow, unsigned int topL
 // only single - line text is supported for now
 void MessageWindow::renderText(unsigned int topLeftPosRow, unsigned int topLeftPosColumn, unsigned int topRightPosColumn, unsigned int bottomLeftPosRow)
 {
-	// a lambda for wrapping up offset calculations
-	auto calcOffset{ [](unsigned int row1, unsigned int row2, unsigned int txtSize) {
-		return (row1 + row2) / 2 - txtSize / 2;
+	// a lambda for wrapping up offset calculations. calculate the middle point between
+	// 2 columns, then adjust it for the text length (...-txtSize/2) so you get the
+	// right offset for the 1st character of the string you want to show on the window,
+	// so in the end it's oriented in the middle
+	auto calcOffset{ [](unsigned int col1, unsigned int col2, unsigned int txtSize) {
+		return (col1 + col2) / 2 - txtSize / 2;
 	} };
 
 	// the distance (+1) of the title and the OK button from the top & bottom borders
 	constexpr unsigned int textBorderDist{ 3 };
 
-	// the title
+	// the title, rendered 3 (textBorderDist) rows after the top border
 	gPacMan.sendDataf(m_title.data(), m_title.size(), topLeftPosRow + textBorderDist, calcOffset(topLeftPosColumn, topRightPosColumn, m_title.size()));
 
 	// if the text goes out of bounds, it will get cut off
@@ -69,7 +72,7 @@ void MessageWindow::renderText(unsigned int topLeftPosRow, unsigned int topLeftP
 	const unsigned int textColumn{ calcOffset(topLeftPosColumn, topRightPosColumn, textSize) };
 	gPacMan.sendDataf(m_msg.data(), textSize, textRow, textColumn);
 
-	// the "OK" text
+	// the "OK" text, rendered 3 (textBorderDist) rows before the bottom border
 	gPacMan.sendDataf(L"> OK <", 6, bottomLeftPosRow - textBorderDist, calcOffset(topLeftPosColumn, topRightPosColumn, 6));
 }
 

--- a/src/Windows/MessageWindow.cpp
+++ b/src/Windows/MessageWindow.cpp
@@ -1,0 +1,70 @@
+#include <Windows.h>
+#include "MessageWindow.h"
+#include "../PacMan.h"
+
+void MessageWindow::render()
+{
+	// render in the middle of the screen
+	const unsigned int topLeftPosRow{ gScreenHeight / 2 - m_height / 2 };
+	const unsigned int topLeftPosColumn{ gScreenWidth / 2 - m_width / 2 };
+
+	const unsigned int topRightPosColumn{ topLeftPosColumn + m_width };
+	const unsigned int bottomLeftPosRow{ topLeftPosRow + m_height };
+
+	// gPacMan.fillscreen() isn't being called here since a message window
+	// doesn't take up the entire screen
+
+	// the top left, top right, buttom left, bottom right textures
+	gPacMan.sendDataf(L'\u2554', topLeftPosRow, topLeftPosColumn);
+	gPacMan.sendDataf(L'\u2557', topLeftPosRow, topRightPosColumn);
+	gPacMan.sendDataf(L'\u255A', bottomLeftPosRow, topLeftPosColumn);
+	gPacMan.sendDataf(L'\u255D', bottomLeftPosRow, topRightPosColumn);
+	// the horizontal bars
+	for (unsigned int i{ 1 }; i < m_width; i++)
+	{
+		gPacMan.sendDataf(L'\u2550', topLeftPosRow, topLeftPosColumn + i);
+		gPacMan.sendDataf(L'\u2550', bottomLeftPosRow, topLeftPosColumn + i);
+		
+		// make the insides of the message window empty
+		for (unsigned int j{ 1 }; j < m_height; j++)
+			gPacMan.sendDataf(L' ', topLeftPosRow + j, topLeftPosColumn + i);
+	}
+	// the vertical bars
+	for (unsigned int i{ 1 }; i < m_height; i++)
+	{
+		gPacMan.sendDataf(L'\u2551', topLeftPosRow + i, topLeftPosColumn);
+		gPacMan.sendDataf(L'\u2551', topLeftPosRow + i, topRightPosColumn);
+	}
+
+	// all text rendering happens below, only single-line text is supported for now
+
+	// a lambda for wrapping up offset calculations
+	auto calcOffset{ [](unsigned int row1, unsigned int row2, unsigned int txtSize) {
+		return (row1 + row2) / 2 - txtSize / 2;
+	} };
+
+	// the distance (+1) of the title and the OK button from the top & bottom borders
+	constexpr unsigned int textBorderDist{ 3 };
+
+	// the title
+	gPacMan.sendDataf(m_title.data(), m_title.size(), topLeftPosRow + textBorderDist, calcOffset(topLeftPosColumn, topRightPosColumn, m_title.size()));
+
+	// if the text goes out of bounds, it will get cut off
+	const unsigned int textSize{ m_msg.size() > m_width ? m_width - 1 : m_msg.size() };
+	const unsigned int textRow{ calcOffset(topLeftPosRow, bottomLeftPosRow, 0) };
+	const unsigned int textColumn{ calcOffset(topLeftPosColumn, topRightPosColumn, textSize) };
+	gPacMan.sendDataf(m_msg.data(), textSize, textRow, textColumn);
+
+	// the "OK" text
+	gPacMan.sendDataf(L"> OK <", 6, bottomLeftPosRow - textBorderDist, calcOffset(topLeftPosColumn, topRightPosColumn, 6) );
+}
+
+void MessageWindow::runLogic()
+{
+	if (GetAsyncKeyState(VK_RETURN) & 0x8000)
+		m_state_terminate = true;
+}
+
+MessageWindow::MessageWindow(unsigned int width, unsigned int height, std::wstring_view title, std::wstring_view msg)
+	: m_width{ width }, m_height{ height }, m_title{ title }, m_msg{ msg }, Window{ WindowType::Other }
+{}

--- a/src/Windows/MessageWindow.h
+++ b/src/Windows/MessageWindow.h
@@ -13,6 +13,11 @@ private:
 
 public:
 	void render() override;
+	// render the horizontal content of the window (the horizontal
+	// bars and the empty space inside it)
+	void renderHorizontalCont(unsigned int, unsigned int, unsigned int);
+	void renderVertCont(unsigned int, unsigned int, unsigned int);
+	void renderText(unsigned int, unsigned int, unsigned int, unsigned int);
 	void runLogic() override;
 
 	// width, height, title, message text

--- a/src/Windows/MessageWindow.h
+++ b/src/Windows/MessageWindow.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <string_view>
+#include "../Engine/Window.h"
+#include "../WindowTypes.h"
+
+// a simple Message Window with an "OK" button. it renders
+// on the middle of the screen
+class MessageWindow : public Window<WindowType>
+{
+private:
+	unsigned int m_width, m_height;
+	std::wstring_view m_title, m_msg;
+
+public:
+	void render() override;
+	void runLogic() override;
+
+	// width, height, title, message text
+	MessageWindow(unsigned int, unsigned int, std::wstring_view, std::wstring_view);
+};


### PR DESCRIPTION
A working message window class that takes a width, height, title name and text as parameters. The width & height don't have an exact 1:1 ratio due to the font rendering being 12 pixels on the X axis and 16 pixels on Y, as defined in `Engine::setupFont()`:
```cpp
void Engine::setupFont()
{
	CONSOLE_FONT_INFOEX fontInfo{};
	fontInfo.cbSize = sizeof(fontInfo);
	fontInfo.nFont = 0;
	fontInfo.dwFontSize.X = 12;
	fontInfo.dwFontSize.Y = 16;
	fontInfo.FontFamily = FF_DONTCARE;
	fontInfo.FontWeight = FF_DONTCARE;
	wcscpy_s(fontInfo.FaceName, L"Consolas");
	SetCurrentConsoleFontEx(m_hConsole, false, &fontInfo);
}
```
The message window doesn't account for this difference
Future TODO: add support for multi-line text rendering